### PR TITLE
Docs/fix create payment session request body

### DIFF
--- a/hosted-checkout/guides/create-payment-session.mdx
+++ b/hosted-checkout/guides/create-payment-session.mdx
@@ -19,11 +19,13 @@ Create a JSON object with the payment details. At a minimum, you must include `c
 | customer | object | Yes | Object containing customer details (first\_name, last\_name, email). |
 | amount\_total | number | Yes | Total charge amount. |
 | currency | string | Yes | Currency code (e.g., "MXN"). |
-| line\_items | array | Yes | Array of objects detailing the items in the cart (name, quantity, unit\_price). |
+| line\_items | array | Yes | Array of objects detailing the items in the cart (name, quantity, unit\_price, product\_id). |
 | return\_url | string | Conditional | Required if success\_url is not set. Fallback redirect URL. |
 | success\_url | string | No | Redirect URL after successful payment. |
 | external\_id | string | No | Your unique identifier for the order (e.g., order ID). |
 | expires\_at | integer | No | Unix timestamp (seconds). Must be 30 min to 24h in future. Default 24h. |
+| payment\_method\_types | array | No | Payment methods to enable for this session. Accepted values: `card`, `mercadopago`, `oxxopay`, `spei`, `safetypayCash`, `safetypayTransfer`. Defaults to `card` if not specified. |
+| metadata | object | No | Optional key-value object for storing additional data with the session. All fields are optional. |
 | ui\_config | object | No | Optional. An object to override the default UI settings for this session. |
 
 See the [API Reference](/hosted-checkout/api/create-session) for a full list of all available fields.
@@ -49,11 +51,14 @@ curl -X POST 'https://api-stage.tonder.io/checkout/v1/sessions' \
       {
         "name": "Blue T-Shirt",
         "quantity": 1,
-        "unit_price": 25000
+        "unit_price": 25000,
+        "product_id": "your-internal-product-id"
       }
     ],
+    "payment_method_types": ["card"],
     "return_url": "https://your-store.com/checkout/complete",
     "external_id": "ORD-2025-A9B8",
+    "metadata": {},
     "ui_config": {
       "branding": {
         "brand_color": "#0066FF"
@@ -77,11 +82,14 @@ const sessionDetails = {
     {
       name: "Blue T-Shirt",
       quantity: 1,
-      unit_price: 25000
+      unit_price: 25000,
+      product_id: "your-internal-product-id"
     }
   ],
+  payment_method_types: ["card"],
   return_url: "https://your-store.com/checkout/complete",
   external_id: "ORD-2025-A9B8",
+  metadata: {},
   ui_config: {
     branding: {
       brand_color: "#0066FF"

--- a/hosted-checkout/guides/create-payment-session.mdx
+++ b/hosted-checkout/guides/create-payment-session.mdx
@@ -41,29 +41,24 @@ curl -X POST 'https://api-stage.tonder.io/checkout/v1/sessions' \
   -H 'Content-Type: application/json' \
   -d '{
     "customer": {
-      "first_name": "Juan",
-      "last_name": "Perez",
-      "email": "juan.perez@example.com"
+      "first_name": "Vicente",
+      "last_name": "Quintero",
+      "email": "vquintero@testuser.com"
     },
-    "amount_total": 25000,
+    "amount_total": 300,
     "currency": "MXN",
     "line_items": [
       {
-        "name": "Blue T-Shirt",
+        "name": "Deposit",
         "quantity": 1,
-        "unit_price": 25000,
-        "product_id": "your-internal-product-id"
+        "unit_price": 10,
+        "product_id": "your_internal_product_id"
       }
     ],
-    "payment_method_types": ["card"],
-    "return_url": "https://your-store.com/checkout/complete",
-    "external_id": "ORD-2025-A9B8",
-    "metadata": {},
-    "ui_config": {
-      "branding": {
-        "brand_color": "#0066FF"
-      }
-    }
+    "payment_method_types": ["spei"],
+    "return_url": "https://tonder.io",
+    "external_id": "ORD-12345-1",
+    "metadata": {}
   }'
 ```
 
@@ -72,29 +67,24 @@ const fetch = require('node-fetch');
 
 const sessionDetails = {
   customer: {
-    first_name: "Juan",
-    last_name: "Perez",
-    email: "juan.perez@example.com"
+    first_name: "Vicente",
+    last_name: "Quintero",
+    email: "vquintero@testuser.com"
   },
-  amount_total: 25000,
+  amount_total: 300,
   currency: "MXN",
   line_items: [
     {
-      name: "Blue T-Shirt",
+      name: "Deposit",
       quantity: 1,
-      unit_price: 25000,
-      product_id: "your-internal-product-id"
+      unit_price: 10,
+      product_id: "your_internal_product_id"
     }
   ],
-  payment_method_types: ["card"],
-  return_url: "https://your-store.com/checkout/complete",
-  external_id: "ORD-2025-A9B8",
-  metadata: {},
-  ui_config: {
-    branding: {
-      brand_color: "#0066FF"
-    }
-  }
+  payment_method_types: ["spei"],
+  return_url: "https://tonder.io",
+  external_id: "ORD-12345-1",
+  metadata: {}
 };
 
 const response = await fetch('https://api-stage.tonder.io/checkout/v1/sessions', {
@@ -110,6 +100,25 @@ const data = await response.json();
 console.log(data);
 ```
 </CodeGroup>
+
+### Payment Method Types
+
+The `payment_method_types` field defines which payment methods are available in the checkout. You should only include the method(s) you want to enable — there is no need to send all of them.
+
+**Available options:**
+
+| Value | Description |
+|---|---|
+| `card` | Credit / Debit card |
+| `mercadopago` | MercadoPago |
+| `oxxopay` | OXXO Pay |
+| `spei` | SPEI (bank transfer) |
+| `safetypayCash` | SafetyPay Cash |
+| `safetypayTransfer` | SafetyPay Transfer |
+
+<Note>
+  In this example, only `spei` is included in `payment_method_types`. Include only the methods relevant to your integration.
+</Note>
 
 ### Step 3: Handle the Response
 


### PR DESCRIPTION
**Title:** `fix(hosted-checkout): fix create session request body examples (TEC-191)`

**Summary:**
- Corrected request body examples in the Create Payment Session guide
- Added `product_id` to `line_items`, `payment_method_types`, and `metadata` fields
- Added `payment_method_types` reference table with all accepted values
- Updated fields table to document new parameters

**Ref:** TEC-191