### PR TITLE
docs(webhooks): fix API Direct payload format in how-webhooks-works

### DIFF
--- a/direct-integration/webhooks/how-webhooks-works.mdx
+++ b/direct-integration/webhooks/how-webhooks-works.mdx
@@ -22,42 +22,71 @@ Tonder sends webhook notifications for various transaction events:
 
 ## Webhook Payload Structure
 
-All webhook notifications follow a consistent payload structure with these key fields:
+API Direct webhooks use a **flat payload** — all fields are at the top level with no nested `data` wrapper. Here are the key fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `event_type` | string | The type of event that occurred (e.g., `transaction.status_changed`) |
-| `event_id` | string | A unique identifier for this specific webhook event |
-| `created_at` | string | An ISO 8601 timestamp of when the event occurred |
-| `data` | object | The full transaction object related to the event |
-| `data.status` | string | The new, current status of the transaction |
-| `data.previous_status` | string | The status of the transaction before this change |
+| `id` | string | Unique identifier for this webhook event |
+| `operation_type` | string | Type of operation (e.g., `payment`) |
+| `amount` | string | Transaction amount as a string |
+| `currency` | string | ISO 4217 currency code (e.g., `MXN`) |
+| `client_reference` | string | Your own reference ID for the transaction |
+| `status` | string | Current transaction status (e.g., `Success`, `Pending`, `Failed`) |
+| `provider` | string | Payment provider that processed the transaction |
+| `transaction_id` | string | Tonder's internal transaction identifier |
+| `payment_method_type` | string | Payment method used (e.g., `SPEI`, `CARD`, `OXXO`) |
+| `created` | string | ISO 8601 timestamp of when the event was created |
+| `metadata` | object | Custom key-value pairs passed when the payment was created |
+| `event_type` | string | Specific event that triggered this notification (e.g., `payment_Success`, `payment_Pending`) |
+| `action` | string | Action associated with the event (e.g., `MODIFY`) |
 
-Here's what a typical webhook payload looks like when a payment status changes:
+Here are examples of the two most common event types:
 
-```json
+<CodeGroup>
+
+```json payment_Success
 {
-  "event_type": "transaction.status_changed",
-  "event_id": "evt_123456789",
-  "created_at": "2024-07-26T10:32:15Z",
-  "data": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "operation_type": "payment",
-    "status": "success",
-    "previous_status": "authorized",
-    "amount": 150.00,
-    "currency": "MXN",
-    "merchant_reference": "order-789",
-    "payment_method": "CARD",
-    "customer": {
-      "name": "Ana María Rodríguez",
-      "email": "ana.rodriguez@email.com"
-    },
-    "completed_at": "2024-07-26T10:32:15Z",
-    "authorization_code": "AUTH123456"
-  }
+  "id": "fc38522e-3e5d-45b8-ba6a-ece72caee71f",
+  "operation_type": "payment",
+  "amount": "70",
+  "currency": "MXN",
+  "client_reference": "f6d16280-7bff-4bb7-b6f1-967f9721248b",
+  "status": "Success",
+  "provider": "tonder",
+  "transaction_id": "e9340a04-6d68-4afc-86c5-79f8b7c87de4",
+  "payment_method_type": "SPEI",
+  "created": "2026-05-21T19:15:32.029134Z",
+  "metadata": {
+    "order_id": "f6d16280-7bff-4bb7-b6f1-967f9721248b",
+    "transaction_type": "deposit"
+  },
+  "event_type": "payment_Success",
+  "action": "MODIFY"
 }
 ```
+
+```json payment_Pending
+{
+  "id": "b47faf2d-844e-4f14-bedd-f998a016cacd",
+  "operation_type": "payment",
+  "amount": "200",
+  "currency": "MXN",
+  "client_reference": "a38f5292-4c5e-42cd-aa73-15763d2d4862",
+  "status": "Pending",
+  "provider": "tonder",
+  "transaction_id": "aa15fe61-a680-40b9-8546-4a98c204dc9d",
+  "payment_method_type": "SPEI",
+  "created": "2026-05-21T21:27:56.220201Z",
+  "metadata": {
+    "order_id": "a38f5292-4c5e-42cd-aa73-15763d2d4862",
+    "transaction_type": "deposit"
+  },
+  "event_type": "payment_Pending",
+  "action": "MODIFY"
+}
+```
+
+</CodeGroup>
 
 ## Getting Started with Webhooks
 
@@ -97,24 +126,24 @@ Here are practical examples showing how to implement webhook handlers for the mo
 
 <Accordion title="Real-time Payment Status Updates">
 
-Handle payment status changes to automatically fulfill orders and notify customers when payments complete or fail.
+Handle payment status changes to automatically fulfill orders when payments complete or fail. Note that the API Direct payload is flat — all fields are at the top level.
 
 ```python
 @app.route('/webhook', methods=['POST'])
 def handle_payment_webhook():
     payload = request.get_json()
     
-    if payload['event_type'] == 'transaction.status_changed':
-        transaction = payload['data']
+    if payload['event_type'] == 'payment_Success':
+        # Payment completed successfully
+        fulfill_order(payload['client_reference'])
         
-        if transaction['status'] == 'success':
-            # Payment completed successfully
-            fulfill_order(transaction['merchant_reference'])
-            send_confirmation_email(transaction['customer']['email'])
-            
-        elif transaction['status'] == 'failed':
-            # Payment failed
-            notify_customer_of_failure(transaction['customer']['email'])
+    elif payload['event_type'] == 'payment_Failed':
+        # Payment failed
+        cancel_order(payload['client_reference'])
+
+    elif payload['event_type'] == 'payment_Pending':
+        # Payment is awaiting confirmation (e.g., SPEI transfer in progress)
+        mark_order_pending(payload['client_reference'])
     
     return jsonify({'status': 'received'}), 200
 ```
@@ -126,16 +155,18 @@ def handle_payment_webhook():
 Process 3D Secure authentication completions to finalize payments that required additional customer verification.
 
 ```python
-def handle_3ds_webhook(payload):
-    transaction = payload['data']
+@app.route('/webhook', methods=['POST'])
+def handle_3ds_webhook():
+    payload = request.get_json()
     
-    if payload['event_type'] == 'transaction.3ds_completed':
-        if transaction['status'] == 'success':
-            # 3DS authentication successful, payment completed
-            complete_order(transaction['id'])
-        else:
-            # 3DS authentication failed
-            cancel_order(transaction['merchant_reference'])
+    if payload['event_type'] == 'payment_Success':
+        # 3DS authentication successful, payment completed
+        complete_order(payload['client_reference'])
+    elif payload['event_type'] == 'payment_Failed':
+        # 3DS authentication failed
+        cancel_order(payload['client_reference'])
+    
+    return jsonify({'status': 'received'}), 200
 ```
 
 </Accordion>


### PR DESCRIPTION
## Summary
- Replaces the legacy nested webhook payload (`data` wrapper, `transaction.status_changed`, etc.) in `direct-integration/webhooks/how-webhooks-works.mdx` with the actual flat API Direct format that merchants receive.
- Updates the field table to document the real top-level fields (`id`, `operation_type`, `amount`, `currency`, `client_reference`, `status`, `provider`, `transaction_id`, `payment_method_type`, `created`, `metadata`, `event_type`, `action`).
- Swaps the single JSON example for a `CodeGroup` with realistic `payment_Success` and `payment_Pending` payloads.
- Rewrites the Python handler examples to read top-level fields and switch on the correct event types (`payment_Success`, `payment_Failed`, `payment_Pending`) instead of the legacy `transaction.status_changed` / nested `data`.

Fixes TEC-273.

## Test plan
- [ ] Preview `direct-integration/webhooks/how-webhooks-works.mdx` in Mintlify and confirm the payload table, JSON `CodeGroup`, and Python snippets render correctly.
- [ ] Verify the documented fields match a real webhook delivery from API Direct (no `data` wrapper, `event_type` is `payment_Success` / `payment_Pending` / `payment_Failed`).
- [ ] Cross-check that the metadata example is consistent with PR #114 (order reference via `metadata.order_id`).